### PR TITLE
Implemented transaction for editing recipes

### DIFF
--- a/lib/service/recipe_service.dart
+++ b/lib/service/recipe_service.dart
@@ -90,43 +90,9 @@ class RecipeService {
 
   Future<void> editRecipe(EntireRecipe entireRecipe) async {
     if (entireRecipe.recipe.id != null) {
-      int newTransfer = -2;
-      int oldTransfer = entireRecipe.recipe.id!;
-
-      try {
-        await RecipeRootsDAO().updateCookingRecipeID(newTransfer, oldTransfer);
-        await RecipeRootsDAO()
-            .updateIngredientRecipeID(newTransfer, oldTransfer);
-        await RecipeRootsDAO().updatePersonRecipeID(newTransfer, oldTransfer);
-
-        await RecipeRootsDAO()
-            .deleteRecipeCookingStepsFromRecipeID(oldTransfer);
-        await RecipeRootsDAO().deleteRecipeIngredientsFromRecipeID(oldTransfer);
-        await RecipeRootsDAO().deletePersonFromRecipe(oldTransfer);
-
-        await RecipeRootsDAO()
-            .addCookingSteps(entireRecipe.cookingSteps, oldTransfer);
-
-        for (Ingredient ingredient in entireRecipe.ingredients) {
-          await RecipeRootsDAO().addIngredients(ingredient, oldTransfer);
-        }
-
-        for (Person person in entireRecipe.authors) {
-          await RecipeRootsDAO().addPersonToRecipe(oldTransfer, person);
-        }
-
-        await RecipeRootsDAO()
-            .deleteRecipeCookingStepsFromRecipeID(newTransfer);
-        await RecipeRootsDAO().deleteRecipeIngredientsFromRecipeID(newTransfer);
-        await RecipeRootsDAO().deletePersonFromRecipe(newTransfer);
-
-        await RecipeRootsDAO().updateRecipe(entireRecipe.recipe);
-      } catch (e) {
-        await RecipeRootsDAO().updateCookingRecipeID(oldTransfer, newTransfer);
-        await RecipeRootsDAO()
-            .updateIngredientRecipeID(oldTransfer, newTransfer);
-        await RecipeRootsDAO().updatePersonRecipeID(oldTransfer, newTransfer);
-      }
+      int id = entireRecipe.recipe.id!;
+      
+      await RecipeRootsDAO().performRecipeEdit(entireRecipe, id);
     } else {
       await addRecipe(entireRecipe);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: recipe_roots
 description: Pocket Sized Family Cook Book.
 publish_to: 'none'
-version: 1.0.3+4
+version: 1.0.4+5
 
 environment:
   sdk: '>=2.19.6 <3.0.0'


### PR DESCRIPTION
Edited recipe_roots_dao and recipe_service to use transaction for editing recipes instead of a try catch block. Simplified the code. Added parameters to various functions to accept a transaction database object.